### PR TITLE
Makefile: Explicitly set shell to Bash.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ clobber delete all files
 endef
 export TASKS
 
+SHELL=/bin/bash
+
 docdir = doc
 helpfiles = $(wildcard $(docdir)/*.txt)
 


### PR DESCRIPTION
This allows the `rm vimhelp{,-ipad,-a4}.pdf` bashism to work on
platforms where GNU make uses another shell by default, i.e. Linux.